### PR TITLE
fix C library name

### DIFF
--- a/lib/resty/mcrypt.lua
+++ b/lib/resty/mcrypt.lua
@@ -26,7 +26,7 @@ int mcrypt_module_close(MCRYPT td);
 int mcrypt_enc_get_iv_size(MCRYPT td);
 ]]
 
-local mcrypt = ffi.load('libmcrypt.so.4')
+local mcrypt = ffi.load('mcrypt')
 
 _M.new = function (self, opts)
     local cipher = opts.cipher


### PR DESCRIPTION
according to
http://luajit.org/ext_ffi_api.html

省略 `lib` 开头和 `.so*` 的结尾
大概能在不同发行版中自动匹配对应的 libmcrypt 吧 _(:з)∠)_